### PR TITLE
Change location URL so it accounts for protocol

### DIFF
--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -5,7 +5,7 @@ const replayBtn = document.querySelector('#replayState')
 
 window.LPTE.onready(async () => {
   const server = await window.constants.getWebServerPort()
-  const location = `http://${server}/pages/op-module-league-champselect-ui`
+  const location = `${window.location.protocol}//${server}/pages/op-module-league-champselect-ui`
 
   const apiKey = await window.constants.getApiKey()
 


### PR DESCRIPTION
Same as https://github.com/rcv-prod-toolkit/module-league-in-game/pull/13

If the tool is running on a reverse proxy with HTTPS, the iframe preview will not work, because the frontend is using https, while requesting an http iframe. 

This change accounts for that.

![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/23201434/42c84d82-dc7f-4ac7-bdd8-d2601bfdfc0c)